### PR TITLE
Add original filename to last_uploaded

### DIFF
--- a/src/server/last_uploaded.go
+++ b/src/server/last_uploaded.go
@@ -16,6 +16,7 @@ type LastUploadedHandler struct {
 // Json returned to the client
 type LastUploadedResponse struct {
 	Name         string    `json:"name"`
+	Original     string    `json:"original"`
 	DeleteKey    string    `json:"delete_key"`
 	CreationTime time.Time `json:"creation_time"`
 }
@@ -33,6 +34,7 @@ func (l *LastUploadedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		entry := l.Server.Metadata.Data[v]
 		lastUploaded[i] = LastUploadedResponse{
 			Name:         entry.Filename,
+			Original:     entry.Original,
 			DeleteKey:    entry.DeleteKey,
 			CreationTime: entry.CreationTime,
 		}


### PR DESCRIPTION
This allows clients to show the last uploaded files much better.

(It might be interesting to also send the tags/ttl in the future)
