### PR TITLE
Implement LastUploaded element removal

### DIFF
--- a/src/server/file.go
+++ b/src/server/file.go
@@ -113,6 +113,18 @@ func (s *Server) ReadFile(filename string) ([]byte, error) {
 func (s *Server) Expire(m Metadata) error {
 	filename := m.Filename
 	delete(s.Metadata.Data, filename)
+
+	lastUploaded := s.Metadata.LastUploaded
+	for i, id := range lastUploaded {
+		if id == filename {
+			if len(lastUploaded) > 1 {
+				s.Metadata.LastUploaded = append(lastUploaded[:i], lastUploaded[i+1:]...)
+			} else {
+				s.Metadata.LastUploaded = nil
+			}
+		}
+	}
+
 	if s.Config.Storage == FS_STORAGE {
 		return os.Remove(s.Config.RuntimeDir + "/" + filename)
 	} else if s.Config.Storage == S3_STORAGE {


### PR DESCRIPTION
There's a bug in upd where deleted files don't get removed from the LastUploaded slice. This causes the server to send an invalid file list, and clients to behave badly : 
![capture d ecran 2015-02-15 a 20 44 33](https://cloud.githubusercontent.com/assets/312529/6205056/469a875e-b561-11e4-8fd1-6ee295356a91.png) 

I decided not to implement any safeguard in last_uploaded or the clients, in order not to hide any LastUploaded bug.

This patch is an attempt to solve the issue. Not sure if it's the right way to remove an element from the slice, but at least it works for me.

Note : I had to manually clean metadata.json, maybe some integrity check would be nice, or maybe regenerate last_uploaded on startup (could be slow)
