### PR TITLE
Autocreate output directory

### DIFF
--- a/src/server/file.go
+++ b/src/server/file.go
@@ -27,6 +27,24 @@ func (s *Server) createS3Config(creds *credentials.Credentials, region string) *
 // to know where and the filename / data to store it.
 func (s *Server) WriteFile(filename string, data []byte) error {
 	if s.Config.Storage == FS_STORAGE {
+		fi, err := os.Stat(s.Config.FSConfig.OutputDirectory)
+		if err != nil && !os.IsNotExist(err) {
+			log.Println("[err] Error while stat'ing the output directory ", s.Config.FSConfig.OutputDirectory)
+			return err
+		}
+
+		if os.IsNotExist(err) {
+			err = os.MkdirAll(s.Config.FSConfig.OutputDirectory, 0755)
+			if err != nil {
+				log.Println("[err] Error while creating the output directory", s.Config.FSConfig.OutputDirectory)
+				return err
+			}
+		}
+
+		if fi != nil && !fi.IsDir() {
+			return fmt.Errorf("%s is not a directory", s.Config.FSConfig.OutputDirectory)
+		}
+
 		file, err := os.Create(s.Config.FSConfig.OutputDirectory + "/" + filename)
 		if err != nil {
 			log.Println("[err] Can't create the file to write: ", filename)

--- a/src/server/send_handler.go
+++ b/src/server/send_handler.go
@@ -114,7 +114,9 @@ func (s *SendHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// writes the data on the storage
-	s.Server.WriteFile(name, data)
+	if err := s.Server.WriteFile(name, data); err != nil {
+		log.Println(err)
+	}
 
 	// add to metadata
 	deleteKey := s.randomString(16)


### PR DESCRIPTION
Auto-create the output directory if it does not exist.

Bail out of WriteFile if the output directory is in fact a file.
