### PR TITLE
Make S3 file upload work again

### DIFF
--- a/src/server/file.go
+++ b/src/server/file.go
@@ -83,6 +83,7 @@ func (s *Server) WriteFile(filename string, data []byte) error {
 		if err != nil {
 			return err
 		}
+		return nil
 	}
 
 	return fmt.Errorf("[err] Unsupported storage: %s", s.Config.Storage)


### PR DESCRIPTION
There was a simple mistake in the file upload logig : s3's writefile forgot to return nil when upload suceeded, so it didn't stop and ended up throwing a generic error.

I think that it has been doing that for a while, but since the error wasn't checked, it still worked. a0cdea1 fixed that though, so S3 had the file, but it was not inserted into the metadata.
