### PR TITLE
The client is now able to read a configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _vendor
 *.swp
+*.exe
 certs/

--- a/client.conf.sample
+++ b/client.conf.sample
@@ -1,0 +1,5 @@
+# The secret key to identify the client. (optional)
+secret_key = ""
+
+# The URL of the server
+server_url = ""


### PR DESCRIPTION
The purpose is to not have to remember/type the URL and secret key every time I use the client.
Being on Windows I can't really use aliases inside cmd.exe, and using a config file feels cleaner.

It uses toml like the server configuration.

Uses https://github.com/vrischmann/userdir to get the most appropriate location for the upd client configuration.

Flags are never overriden if they're not the default.
