### PR TITLE
last uploaded: don't add an entry to the response if its metadata is empty

### DIFF
--- a/src/server/last_uploaded.go
+++ b/src/server/last_uploaded.go
@@ -48,6 +48,10 @@ func (l *LastUploadedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			continue
 		}
 
+		if metadata == nil {
+			continue
+		}
+
 		lastUploadedResp = append(lastUploadedResp, LastUploadedResponse{
 			Name:         metadata.Filename,
 			Original:     metadata.Original,

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -144,13 +144,15 @@ func (s *Server) deleteMetadata(name string) error {
 // getEntry looks in the Bolt DB whether this entry exists and returns it
 // if found, otherwise, nil is returned.
 func (s *Server) GetEntry(id string) (*Metadata, error) {
-	var metadata Metadata
+	var metadata *Metadata
 	err := s.Database.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("Metadata"))
 		v := bucket.Get([]byte(id))
 		if v == nil {
 			return nil
 		}
+
+		metadata = new(Metadata)
 
 		// unmarshal the bytes
 		err := json.Unmarshal(v, &metadata)
@@ -161,7 +163,7 @@ func (s *Server) GetEntry(id string) (*Metadata, error) {
 		return nil
 	})
 
-	return &metadata, err
+	return metadata, err
 }
 
 // GetLastUploaded reads into BoltDB the array


### PR DESCRIPTION
I have some entries returned by GetLastUploaded() that don't exist (I assume because they're deleted). This PR ignores them.
